### PR TITLE
Added basic PMS7003 value reading code.

### DIFF
--- a/AirQualitySensor/AirQualitySensor.ino
+++ b/AirQualitySensor/AirQualitySensor.ino
@@ -75,6 +75,8 @@ void printValues() {
  * 
  * Based on PMS Library by Marcin Kacki 
  * and code examples from https://github.com/fu-hsi/PMS
+ * 
+ * PMS 7003 Pinout: https://www.espruino.com/refimages/PMS7003_PMS7003_pins.gif
  * Wiring on NodeMCU (for PMS7003 module):
  * 
  *          PMS7003 <-> NodeMCU

--- a/AirQualitySensor/AirQualitySensor.ino
+++ b/AirQualitySensor/AirQualitySensor.ino
@@ -10,17 +10,17 @@
  *    SDA <-> D2 (GPIO4)
  */
 
-
+/*
 #include <Wire.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_BME280.h>
-
+*/
 /*#include <SPI.h>
 #define BME_SCK 14
 #define BME_MISO 12
 #define BME_MOSI 13
 #define BME_CS 15*/
-
+/*
 #define SEALEVELPRESSURE_HPA (1013.25)
 
 Adafruit_BME280 bme; // I2C
@@ -68,4 +68,55 @@ void printValues() {
   Serial.println(" %");
 
   Serial.println();
+}*/
+
+
+/*
+ * 
+ * Based on PMS Library by Marcin Kacki 
+ * and code examples from https://github.com/fu-hsi/PMS
+ * Wiring on NodeMCU (for PMS7003 module):
+ * 
+ *          PMS7003 <-> NodeMCU
+ *          
+ *    Pin 1,2 (+5V) <-> +5V
+ *    Pin 3,4 (GND) <-> GND
+ *    Pin 7 (RX)    <-> D4 (TX/GPIO2)
+ *    Pin 9 (TX)    <-> D3 (RX/GPIO0)
+ *    
+ *    Note: For +5V you should use external 5V power supply
+ *    and connect it's ground with NodeMCU GND. 
+ *    You should hear and feel PMS7003 fan working 
+ *    when it has enough voltage and current.
+ */
+
+#include "PMS.h"
+#include <SoftwareSerial.h>
+
+SoftwareSerial pmsSerial(D3, D4);
+
+PMS pms(pmsSerial);
+PMS::DATA data;
+
+void setup()
+{
+  Serial.begin(115200);   
+  pmsSerial.begin(9600);  
+}
+
+void loop()
+{
+  if (pms.read(data))
+  {
+    Serial.print("PM 1.0 (ug/m3): ");
+    Serial.println(data.PM_AE_UG_1_0);
+
+    Serial.print("PM 2.5 (ug/m3): ");
+    Serial.println(data.PM_AE_UG_2_5);
+
+    Serial.print("PM 10.0 (ug/m3): ");
+    Serial.println(data.PM_AE_UG_10_0);
+
+    Serial.println();
+  }
 }


### PR DESCRIPTION
Temporary disabled code for handling BME280. 

Next steps:
- modify the code to read values from BME280 and PMS7003 at the same time
- add sending values over WiFi
- add documentation on hardware connections and usage